### PR TITLE
Fix PropTypes for style

### DIFF
--- a/FloatingHearts.js
+++ b/FloatingHearts.js
@@ -174,7 +174,7 @@ class AnimatedShape extends Component {
 AnimatedShape.propTypes = {
   height: PropTypes.number.isRequired,
   onComplete: PropTypes.func.isRequired,
-  style: View.propTypes.style,
+  style: PropTypes.style,
   children: PropTypes.node.isRequired,
 }
 


### PR DESCRIPTION
View.propTypes.style isn't valid and printed a deprecation message for several releases before it was removed. Use ViewPropTypes.style instead.